### PR TITLE
Add basic front‑end templates and routes

### DIFF
--- a/SportSlot/app/__init__.py
+++ b/SportSlot/app/__init__.py
@@ -12,6 +12,13 @@ def create_app():
 
     # Đăng ký Blueprint
     from app.routes.auth import auth_bp
+    from app.routes.customer_routes import customer_bp
+    from app.routes.owner_routes import owner_bp
+    from app.routes.admin_routes import admin_bp
+
     app.register_blueprint(auth_bp)
+    app.register_blueprint(customer_bp)
+    app.register_blueprint(owner_bp)
+    app.register_blueprint(admin_bp)
 
     return app

--- a/SportSlot/app/config.py
+++ b/SportSlot/app/config.py
@@ -1,0 +1,3 @@
+class Config:
+    SECRET_KEY = 'dev'
+    MONGO_URI = 'mongodb://localhost:27017/sportslot'

--- a/SportSlot/app/routes/admin_routes.py
+++ b/SportSlot/app/routes/admin_routes.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, render_template
+
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+@admin_bp.route('/dashboard')
+def dashboard():
+    return render_template('admin/dashboard.html')
+
+@admin_bp.route('/users')
+def users():
+    return render_template('admin/manage_users.html')
+
+@admin_bp.route('/revenue')
+def revenue():
+    return render_template('admin/revenue_report.html')

--- a/SportSlot/app/routes/auth.py
+++ b/SportSlot/app/routes/auth.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, render_template, redirect, url_for, request, session, flash
+
+auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        session['user_id'] = request.form.get('username')
+        flash('Logged in successfully', 'success')
+        return redirect(url_for('customer.home'))
+    return render_template('auth/login.html')
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        flash('Registration successful', 'success')
+        return redirect(url_for('auth.login'))
+    return render_template('auth/register.html')
+
+@auth_bp.route('/logout')
+def logout():
+    session.clear()
+    flash('Logged out', 'info')
+    return redirect(url_for('auth.login'))

--- a/SportSlot/app/routes/customer_routes.py
+++ b/SportSlot/app/routes/customer_routes.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, render_template
+
+customer_bp = Blueprint('customer', __name__)
+
+@customer_bp.route('/')
+def home():
+    return render_template('customer/court_list.html')
+
+@customer_bp.route('/dashboard')
+def dashboard():
+    return render_template('customer/dashboard.html', user={'username': 'Demo'})
+
+@customer_bp.route('/history')
+def history():
+    return render_template('customer/history.html')
+
+@customer_bp.route('/book', methods=['GET', 'POST'])
+def book():
+    return render_template('customer/booking_form.html')

--- a/SportSlot/app/routes/owner_routes.py
+++ b/SportSlot/app/routes/owner_routes.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, render_template
+
+owner_bp = Blueprint('owner', __name__, url_prefix='/owner')
+
+@owner_bp.route('/dashboard')
+def dashboard():
+    return render_template('owner/dashboard.html')
+
+@owner_bp.route('/courts')
+def courts():
+    return render_template('owner/manage_courts.html')
+
+@owner_bp.route('/bookings')
+def bookings():
+    return render_template('owner/booking_list.html')

--- a/SportSlot/app/static/css/style.css
+++ b/SportSlot/app/static/css/style.css
@@ -1,0 +1,3 @@
+body {
+  padding-bottom: 60px;
+}

--- a/SportSlot/app/templates/404.html
+++ b/SportSlot/app/templates/404.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block title %}Page Not Found{% endblock %}
+{% block content %}
+<h2>404 - Page Not Found</h2>
+<p>The page you are looking for does not exist.</p>
+{% endblock %}

--- a/SportSlot/app/templates/admin/dashboard.html
+++ b/SportSlot/app/templates/admin/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block title %}Admin Dashboard{% endblock %}
+{% block content %}
+<h2>Admin Dashboard</h2>
+<p>System overview metrics.</p>
+{% endblock %}

--- a/SportSlot/app/templates/admin/manage_users.html
+++ b/SportSlot/app/templates/admin/manage_users.html
@@ -1,0 +1,21 @@
+{% extends 'layout.html' %}
+{% block title %}Manage Users{% endblock %}
+{% block content %}
+<h2>User Management</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Role</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>user1</td>
+      <td>customer</td>
+      <td><a href="#" class="btn btn-sm btn-outline-secondary">Block</a></td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/SportSlot/app/templates/admin/revenue_report.html
+++ b/SportSlot/app/templates/admin/revenue_report.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block title %}Revenue Report{% endblock %}
+{% block content %}
+<h2>Revenue Report</h2>
+<p>Statistics placeholder.</p>
+{% endblock %}

--- a/SportSlot/app/templates/auth/login.html
+++ b/SportSlot/app/templates/auth/login.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/SportSlot/app/templates/auth/register.html
+++ b/SportSlot/app/templates/auth/register.html
@@ -1,0 +1,35 @@
+{% extends 'layout.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <div class="mb-3">
+    <label for="fullname" class="form-label">Full Name</label>
+    <input type="text" class="form-control" id="fullname" name="fullname" required>
+  </div>
+  <div class="mb-3">
+    <label for="phone" class="form-label">Phone</label>
+    <input type="tel" class="form-control" id="phone" name="phone" required>
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">Email</label>
+    <input type="email" class="form-control" id="email" name="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="role" class="form-label">Role</label>
+    <select class="form-select" id="role" name="role">
+      <option value="customer">Customer</option>
+      <option value="owner">Field Owner</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+{% endblock %}

--- a/SportSlot/app/templates/customer/booking_form.html
+++ b/SportSlot/app/templates/customer/booking_form.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block title %}Book Court{% endblock %}
+{% block content %}
+<h2>Book Court</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Date</label>
+    <input type="date" class="form-control" name="date" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Time</label>
+    <input type="time" class="form-control" name="time" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Voucher</label>
+    <input type="text" class="form-control" name="voucher">
+  </div>
+  <button class="btn btn-success">Book</button>
+</form>
+{% endblock %}

--- a/SportSlot/app/templates/customer/court_list.html
+++ b/SportSlot/app/templates/customer/court_list.html
@@ -1,0 +1,32 @@
+{% extends 'layout.html' %}
+{% block title %}Courts{% endblock %}
+{% block content %}
+<h2>Available Courts</h2>
+<form class="row g-3 mb-3">
+  <div class="col-md-4">
+    <input type="text" class="form-control" placeholder="Search...">
+  </div>
+  <div class="col-md-3">
+    <select class="form-select">
+      <option selected>Sport Type</option>
+    </select>
+  </div>
+  <div class="col-md-3">
+    <input type="date" class="form-control">
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-primary w-100">Filter</button>
+  </div>
+</form>
+<div class="row">
+  <div class="col-md-4" *ngFor="court in courts">
+    <div class="card mb-4">
+      <div class="card-body">
+        <h5 class="card-title">Court Name</h5>
+        <p class="card-text">Location</p>
+        <a href="#" class="btn btn-sm btn-outline-primary">View</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/SportSlot/app/templates/customer/dashboard.html
+++ b/SportSlot/app/templates/customer/dashboard.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block title %}Customer Dashboard{% endblock %}
+{% block content %}
+<h2>Welcome, {{ user.username }}</h2>
+<p>This is your dashboard.</p>
+<ul>
+  <li><a href="#">Booking History</a></li>
+  <li><a href="#">Profile</a></li>
+</ul>
+{% endblock %}

--- a/SportSlot/app/templates/customer/history.html
+++ b/SportSlot/app/templates/customer/history.html
@@ -1,0 +1,21 @@
+{% extends 'layout.html' %}
+{% block title %}Booking History{% endblock %}
+{% block content %}
+<h2>Booking History</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Date</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Example Court</td>
+      <td>2024-01-01</td>
+      <td>Confirmed</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/SportSlot/app/templates/layout.html
+++ b/SportSlot/app/templates/layout.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}SportSlot{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  {% block head %}{% endblock %}
+</head>
+<body>
+  {% include 'partials/navbar.html' %}
+  <main class="container mt-4">
+    {% include 'partials/messages.html' %}
+    {% block content %}{% endblock %}
+  </main>
+  {% include 'partials/footer.html' %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/SportSlot/app/templates/owner/booking_list.html
+++ b/SportSlot/app/templates/owner/booking_list.html
@@ -1,0 +1,23 @@
+{% extends 'layout.html' %}
+{% block title %}Booking Schedule{% endblock %}
+{% block content %}
+<h2>Booking Schedule</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Court</th>
+      <th>Date</th>
+      <th>User</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Court 1</td>
+      <td>2024-01-01</td>
+      <td>John</td>
+      <td>Confirmed</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/SportSlot/app/templates/owner/dashboard.html
+++ b/SportSlot/app/templates/owner/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block title %}Owner Dashboard{% endblock %}
+{% block content %}
+<h2>Owner Dashboard</h2>
+<p>Overview of your fields and bookings.</p>
+{% endblock %}

--- a/SportSlot/app/templates/owner/manage_courts.html
+++ b/SportSlot/app/templates/owner/manage_courts.html
@@ -1,0 +1,21 @@
+{% extends 'layout.html' %}
+{% block title %}Manage Courts{% endblock %}
+{% block content %}
+<h2>My Courts</h2>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Status</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Court 1</td>
+      <td>Active</td>
+      <td><a href="#" class="btn btn-sm btn-outline-secondary">Edit</a></td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/SportSlot/app/templates/partials/footer.html
+++ b/SportSlot/app/templates/partials/footer.html
@@ -1,0 +1,5 @@
+<footer class="footer mt-auto py-3 bg-light">
+  <div class="container text-center">
+    <span class="text-muted">&copy; 2024 SportSlot</span>
+  </div>
+</footer>

--- a/SportSlot/app/templates/partials/messages.html
+++ b/SportSlot/app/templates/partials/messages.html
@@ -1,0 +1,10 @@
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}

--- a/SportSlot/app/templates/partials/navbar.html
+++ b/SportSlot/app/templates/partials/navbar.html
@@ -1,0 +1,27 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">SportSlot</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        {% if session.get('user_id') %}
+        <li class="nav-item">
+          <a class="nav-link" href="#">Dashboard</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
+        </li>
+        {% else %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.login') }}">Login</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auth.register') }}">Register</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- add base HTML layout with navbar, messages, and footer
- implement auth pages and placeholders for customer, owner, and admin views
- create minimal blueprints for each role and register them in the app factory
- provide default config and style sheet
- include a custom 404 page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python SportSlot/run.py` *(verified server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6873bf87321c8323999bbc1b71fc620a